### PR TITLE
Update doc and disable debloat for windows 10

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ This project has only been tested on Ubuntu Linux host machine.
   * Virtualbox (the only supported at the moment)
 * packer - https://www.packer.io/
 * packer plugin
-  * Windows update - https://github.com/rgl/packer-provisioner-windows-update
+  * Windows update - https://github.com/rgl/packer-provisioner-windows-update. Instructions [here](https://www.packer.io/docs/plugins)
 * vagrant - https://www.vagrantup.com/
 
 ## Installation
@@ -32,7 +32,8 @@ The use `build-boxes`, you need to install the python depedencies. They can easi
 
 ```
 git clone https://github.com/df3l0p/build-boxes.git
-python3 -m pipenv install
+python3 -m pipenv install                           # for python 3.6
+python3 -m pipenv install --path=/usr/bin/python3.8 # For python>3.6
 ```
 
 To switch in the pipenv environment

--- a/res/scripts/Optimize-OS.ps1
+++ b/res/scripts/Optimize-OS.ps1
@@ -197,6 +197,7 @@ Disable-IPv6
 Disable-Hibernation
 Set-PowerPlanToHighPerformance
 Disable-BootManager
-Unlock-WindowsWithW4RH4WK
+# ERROR EXCEPTION:  ERROR EXCEPTION:    at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
+#Unlock-WindowsWithW4RH4WK
 # todo: bug Removing CloudStore from registry if it exists. ERROR: Cannot convert the "Explorer.exe" value of type "System.String" to type "System.Diagnostics.Process".
 #Unlock-WindowsWithSycnex


### PR DESCRIPTION
# Summary

This PR updates the doc and disables the debloat function for Windows 10.
The new boxes have been built and tested for Windows 10 and Windows 2019.